### PR TITLE
Little fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,17 +14,16 @@
   "author": "Simon Räss",
   "license": "Apache-2.0",
   "dependencies": {
-    "express": "~4.12.4",
-    "request": "~2.57.0",
+    "array-filter": "~1.0.0",
+    "array.prototype.find": "~1.0.0",
+    "basic-auth": "~1.0.3",
+    "body-parser": "~1.14.1",
+    "compression": "~1.5.2",
     "csv": "~0.4.2",
     "csv-parse": "~0.1.2",
-    "iconv": "~2.1.8",
-    "array.prototype.find": "~1.0.0",
-    "array-filter": "~1.0.0",
-    "body-parser": "~1.14.1",
-    "sanitize-filename": "~1.5.3",
-    "basic-auth": "~1.0.3",
-    "compression": "~1.5.2"
+    "express": "~4.12.4",
+    "request": "~2.57.0",
+    "sanitize-filename": "~1.5.3"
   },
   "devDependencies": {
     "mocha": "~2.2.5",

--- a/services/local-loader.js
+++ b/services/local-loader.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 var request = require('request');
-var iconv = require('iconv');
 var reformatTime = require('./time').reformatTime;
 var parseTime = require('./time').parseTime;
 
@@ -23,16 +22,13 @@ module.exports = function(id, callback) {
     url: 'http://localhost:3000/api/events/' + id
   }, function(error, response, body) {
     if (response.statusCode === 404) {
-      response.statusCode = 404;
-      response.json({
-        statusCode: 404,
-        message: 'event with id ' + id + ' does not exist'
-      });
+      var customResponse = {
+        statusMessage: 404,
+        message: 'a competition with this ' + id + 'does not exist'
+      };
+      callback(customResponse);
       return;
     }
-    
-    // hack to fix invalid encoding from SOLV server
-    var converted = body;
     
     // convert CSV to JSON
     var categories = { };

--- a/services/solv-loader.js
+++ b/services/solv-loader.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 var request = require('request');
-var iconv = require('iconv');
 var reformatTime = require('./time').reformatTime;
 var parseTime = require('./time').parseTime;
 
@@ -32,18 +31,13 @@ module.exports = function(id, callback) {
   }, function(error, response, body) {
     // interpret unknown event - SOLV does not properly do that for us...
     if (response.statusCode === 404 || body.substring(0, 14) === '<!DOCTYPE html') {
-      response.statusCode = 404;
-      response.json({
-        statusCode: 404,
-        message: 'event with id ' + id + ' does not exist'
-      });
+      var customResponse = {
+        statusMessage: 404,
+        message: 'a competition with this ' + id + 'does not exist'
+      };
+      callback(customResponse);
       return;
     }
-    
-    // hack to fix invalid encoding from SOLV server
-    var buffer = new Buffer(body, 'binary');
-    var conv = new iconv.Iconv('windows-1252', 'utf8');
-    var converted = conv.convert(body).toString();
     
     // convert CSV to JSON
     var categories = { };


### PR DESCRIPTION
# Zerscht mol e grosses dangge
E richtig gueti aktion isch diä repo.

## Error
 * When requesting ``` http://localhost:3000/api/events/solv/4602 ``` or all these events 4602,4798,4796,4790 (2018) tested with fantasyOrienteering.com. 
There is some failure with the conversion we do not need anymore. I do strongly believe that these are artefacts.

* Second Error: When a id is requested and there is no competition matching the id.

## Terminal output first error

```
/Users/jannis/Documents/Work/orienteering.api/node_modules/iconv/lib/iconv.js:147
        throw errnoException('EILSEQ', 'Illegal character sequence.');
        ^

Error: Illegal character sequence.
    at errnoException (/Users/jannis/Documents/Work/orienteering.api/node_modules/iconv/lib/iconv.js:175:13)
    at convert (/Users/jannis/Documents/Work/orienteering.api/node_modules/iconv/lib/iconv.js:147:15)
    at Iconv.convert (/Users/jannis/Documents/Work/orienteering.api/node_modules/iconv/lib/iconv.js:64:12)
    at Request._callback (/Users/jannis/Documents/Work/orienteering.api/services/solv-loader.js:46:26)
    at Request.self.callback (/Users/jannis/Documents/Work/orienteering.api/node_modules/request/request.js:354:22)
    at Request.emit (events.js:182:13)
    at Request.<anonymous> (/Users/jannis/Documents/Work/orienteering.api/node_modules/request/request.js:1207:14)
    at Request.emit (events.js:187:15)
    at IncomingMessage.<anonymous> (/Users/jannis/Documents/Work/orienteering.api/node_modules/request/request.js:1153:12)
    at IncomingMessage.emit (events.js:187:15)
```
## Terminal output second error
```
/Users/jannis/Documents/Work/orienteering.api/services/solv-loader.js:36
      response.json({
               ^

TypeError: response.json is not a function
    at Request._callback (/Users/jannis/Documents/Work/orienteering.api/services/solv-loader.js:36:16)
    at Request.self.callback (/Users/jannis/Documents/Work/orienteering.api/node_modules/request/request.js:354:22)
    at Request.emit (events.js:182:13)
    at Request.<anonymous> (/Users/jannis/Documents/Work/orienteering.api/node_modules/request/request.js:1207:14)
    at Request.emit (events.js:187:15)
    at IncomingMessage.<anonymous> (/Users/jannis/Documents/Work/orienteering.api/node_modules/request/request.js:1153:12)
    at IncomingMessage.emit (events.js:187:15)
    at endReadableNT (_stream_readable.js:1085:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```
### Also fixing

```
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead. 
```
due to that we also don't need the buffer
